### PR TITLE
New: build and release ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Test Build
+on: [push]
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          default: true
+      
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      
+      - name: Install dependencies
+        run: pip install maturin
+      
+      - name: Build wheel
+        run: maturin build --release
+      
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.os }}-cp${{ matrix.python-version }}
+          path: target/wheels
+
+
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
-name: Test Build
-on: [push]
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
 jobs:
   build:
     name: Build
@@ -54,8 +57,10 @@ jobs:
       - name: Build wheel
         run: maturin build --release --strip
       
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@master
         with:
-          name: ${{ matrix.os }}-cp${{ matrix.python-version }}
-          path: target/wheels
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: target/wheels/
+          skip_existing: true


### PR DESCRIPTION
- test build on push and upload to artifacts
- release to pypi when push tag startswith `v*`

building with cache support

add `PYPI_API_TOKEN` secret before using release workflow